### PR TITLE
fix: Generalized LiliumElytra$Renderer

### DIFF
--- a/src/main/java/xyz/lilyflower/lilium/item/LiliumElytra.java
+++ b/src/main/java/xyz/lilyflower/lilium/item/LiliumElytra.java
@@ -3,7 +3,6 @@ package xyz.lilyflower.lilium.item;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.entity.event.v1.FabricElytraItem;
-import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
@@ -14,15 +13,14 @@ import net.minecraft.client.render.entity.model.EntityModel;
 import net.minecraft.client.render.entity.model.EntityModelLayers;
 import net.minecraft.client.render.entity.model.EntityModelLoader;
 import net.minecraft.client.render.item.ItemRenderer;
-import net.minecraft.client.util.SkinTextures;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.player.PlayerModelPart;
 import net.minecraft.item.ElytraItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Rarity;
 import xyz.lilyflower.lilium.util.registry.item.LiliumElytras;
@@ -45,24 +43,12 @@ public class LiliumElytra extends ElytraItem implements FabricElytraItem {
         public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f, float g, float h, float j, float k, float l) {
             ItemStack stack = livingEntity.getEquippedStack(EquipmentSlot.CHEST);
             if (stack.isIn(LiliumElytras.ELYTRAS) && !stack.isOf(Items.ELYTRA)) {
-                Identifier texture;
-                String name = stack.getItem().getTranslationKey().replace("item.lilium.", "");
-
-                if (livingEntity instanceof AbstractClientPlayerEntity player) {
-                    SkinTextures skinTextures = player.getSkinTextures();
-                    if (skinTextures.elytraTexture() != null) {
-                        texture = skinTextures.elytraTexture();
-                    } else if (skinTextures.capeTexture() != null && player.isPartVisible(PlayerModelPart.CAPE)) {
-                        texture = skinTextures.capeTexture();
-                    } else {
-                        texture = Identifier.of("lilium", "textures/entity/elytra/" + name + ".png");
-                    }
-                } else {
-                    texture = Identifier.of("lilium", "textures/entity/elytra/" + name + ".png");
-                }
+                Identifier texture = Registries.ITEM.getId(stack.getItem()).withPrefixedPath("textures/entity/elytra/");
 
                 if (stack.getName().getString().equals("Suspicious " + stack.getItem().getName().getString())) {
-                    texture = Identifier.of("lilium", "textures/entity/elytra/" + name + "_suspicious.png");
+                    texture = texture.withSuffixedPath("_suspicious.png");
+                } else {
+                    texture = texture.withSuffixedPath(".png");
                 }
 
                 matrixStack.push();


### PR DESCRIPTION
Note: Does remove special-casing of the cape renderer.

In fairness, you'd probably just stick to the vanilla elytra if you wanted the cape to override.